### PR TITLE
Omit triggering Unexpected MOODLE_INTERNAL check warnings.

### DIFF
--- a/classes/event/behaviour_exported.php
+++ b/classes/event/behaviour_exported.php
@@ -25,8 +25,6 @@
 
 namespace block_behaviour\event;
 
-defined('MOODLE_INTERNAL') || die();
-
 /**
  * The event class.
  *

--- a/classes/event/behaviour_imported.php
+++ b/classes/event/behaviour_imported.php
@@ -25,8 +25,6 @@
 
 namespace block_behaviour\event;
 
-defined('MOODLE_INTERNAL') || die();
-
 /**
  * The event class.
  *

--- a/classes/event/behaviour_viewed.php
+++ b/classes/event/behaviour_viewed.php
@@ -25,8 +25,6 @@
 
 namespace block_behaviour\event;
 
-defined('MOODLE_INTERNAL') || die();
-
 /**
  * The event class.
  *

--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -25,8 +25,6 @@
 
 namespace block_behaviour\privacy;
 
-defined('MOODLE_INTERNAL') || die();
-
 use core_privacy\local\request\approved_contextlist;
 use core_privacy\local\request\contextlist;
 use core_privacy\local\request\writer;

--- a/db/install.php
+++ b/db/install.php
@@ -23,8 +23,6 @@
  * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-defined('MOODLE_INTERNAL') || die();
-
 /**
  * The install function.
  */

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -23,8 +23,6 @@
  * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-defined('MOODLE_INTERNAL') || die();
-
 /**
  * The upgrade function.
  *


### PR DESCRIPTION
This sets your badge green again.